### PR TITLE
解决开启HTML压缩后的标题错位问题

### DIFF
--- a/header.php
+++ b/header.php
@@ -253,7 +253,7 @@
 		<span></span>
 	</div>
 	<div id="banner_container" class="banner-container container text-center">
-		<h1 class="banner-title text-white"><?php echo get_option('argon_banner_title') == '' ? bloginfo('name') : get_option('argon_banner_title'); ?><?php echo get_option('argon_banner_subtitle') == '' ? '' : '<p class="banner-subtitle">' . get_option('argon_banner_subtitle') . '</p>'; ?></h1>
+		<h1 class="banner-title text-white"><?php echo get_option('argon_banner_title') == '' ? bloginfo('name') : get_option('argon_banner_title'); ?><?php echo get_option('argon_banner_subtitle') == '' ? '' : '<span class="banner-subtitle d-block">' . get_option('argon_banner_subtitle') . '</span>'; ?></h1>
 	</div>
 	<?php if (get_option('argon_banner_background_url') != '') { ?>
 		<style>


### PR DESCRIPTION
当使用 WP Performance 压缩HTML代码时，H1标签内的P标签会被处理成和H1平级，估计是压缩程序不允许将P标签放在H1导致；将P标签改为span行内标签后问题解决