### PR TITLE
解决文章内的第一个figure间距过大问题

### DIFF
--- a/assets/scss/custom/_type.scss
+++ b/assets/scss/custom/_type.scss
@@ -84,7 +84,10 @@ article {
 	}
 
 	figure {
-		margin: 3rem 0;
+                &:first-child {
+                        margin: 0 0 1rem;
+                }
+                margin: 3rem 0;
 	}
 
 	h5 + figure {


### PR DESCRIPTION
如果文章第一个是一张图片，则上下间距3rem在加上header的下边距一起有点太大了