### PR TITLE
修复 PHP 'Cannot modify header information' 的报错

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -344,10 +344,13 @@ function set_user_token_cookie(){
 		$_COOKIE["argon_user_token"] = $newToken;
 	}
 }
-set_user_token_cookie();
-if (!session_id()){
-	session_start();
+function session_init(){
+	set_user_token_cookie();
+	if (!session_id()){
+		session_start();
+	}
 }
+add_action('setup_theme', 'session_init');
 //页面 Description Meta
 function get_seo_description(){
 	global $post;


### PR DESCRIPTION
### 日志内容
```
PHP Warning:  Cannot modify header information - headers already sent in /wordpress/wp-content/themes/argon/functions.php on line 343
[08-Sep-2021 05:08:00 UTC] PHP Warning:  session_start(): Cannot start session when headers already sent in /wordpress/wp-content/themes/argon/functions.php on line 349
```

### 启用插件
- WPJAM BASIC
- Code Snippets
- WP Editor.MD
- Redis Object Cache
- Akismet

### 解决方案（见PR）
提高 setcookie 和 session_start 函数的加载优先级