### PR TITLE
fix shortcode problem of collapse

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -2360,7 +2360,7 @@ function shortcode_collapse_block($attr,$content=""){
 	$out = "<div " ;
 	$out .= " class='collapse-block shadow-sm";
 	$color = $attr['color'] ?? 'none';
-	$title = $attr['title'] ?? 'untitled';
+	$title = $attr['title'] ?? '';
 	switch ($color){
 		case 'indigo':
 			$out .= " collapse-block-primary";

--- a/functions.php
+++ b/functions.php
@@ -2360,6 +2360,7 @@ function shortcode_collapse_block($attr,$content=""){
 	$out = "<div " ;
 	$out .= " class='collapse-block shadow-sm";
 	$color = $attr['color'] ?? 'none';
+	$title = $attr['title'] ?? 'untitled';
 	switch ($color){
 		case 'indigo':
 			$out .= " collapse-block-primary";
@@ -2399,7 +2400,7 @@ function shortcode_collapse_block($attr,$content=""){
 	if (isset($attr['icon'])){
 		$out .= "<i class='fa fa-" . $attr['icon'] . "'></i> ";
 	}
-	$out .= "<span class='collapse-block-title-inner'>" . $attr['title'] . "</span><i class='collapse-icon fa fa-angle-down'></i></div>";
+	$out .= "<span class='collapse-block-title-inner'>" . $title . "</span><i class='collapse-icon fa fa-angle-down'></i></div>";
 
 	$out .= "<div class='collapse-block-body'";
 	if ($collapsed != 'false'){


### PR DESCRIPTION
默认的折叠区块似乎只能添加文本而无法添加自定义区块
为了添加自定义区块，需要手写shortcode，而如果在手动写shortcode时没有给collpse短代码添加title字段，则会导致500错误而无法更改文章内容
![screenshots](https://styunlen.cn/wp-content/uploads/2022/01/qq20220105223904.png)
修改了两行代码来修复这个问题
不过，貌似可以修改折叠区块的Gutenberg源码来更改折叠区块的类型，让他继承wp-group区块的属性，这样也许就能完成区块内嵌套区块了，奈何我水平不足，大大可以解决下