### PR TITLE
修改获取主题版本号的方式，以防止获取的是子主题的版本号带来的CDN加载出错的问题

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -9,18 +9,19 @@ function theme_slug_setup() {
 }
 add_action('after_setup_theme','theme_slug_setup');
 
-$GLOBALS['theme_version'] = wp_get_theme() -> Version;
+$argon_version = !(wp_get_theme() -> Template) ? wp_get_theme() -> Version : wp_get_theme(wp_get_theme() -> Template) -> Version;
+$GLOBALS['theme_version'] = $argon_version;
 $argon_assets_path = get_option("argon_assets_path");
 switch ($argon_assets_path) {
     case "jsdelivr":
-	    $GLOBALS['assets_path'] = "https://cdn.jsdelivr.net/gh/solstice23/argon-theme@" . wp_get_theme() -> Version;
+	    $GLOBALS['assets_path'] = "https://cdn.jsdelivr.net/gh/solstice23/argon-theme@" . $argon_version;
         break;
     case "fastgit":
-	    $GLOBALS['assets_path'] = "https://raw.fastgit.org/solstice23/argon-theme/v" . wp_get_theme() -> Version;
+	    $GLOBALS['assets_path'] = "https://raw.fastgit.org/solstice23/argon-theme/v" . $argon_version;
         break;
     case "AHCDN":
     case "sourcestorage":
-	    $GLOBALS['assets_path'] = "https://source.ahdark.com/wordpress/theme/argon-theme/" . wp_get_theme() -> Version;
+	    $GLOBALS['assets_path'] = "https://source.ahdark.com/wordpress/theme/argon-theme/" . $argon_version;
         break;
     default:
 	    $GLOBALS['assets_path'] = get_bloginfo('template_url');

--- a/functions.php
+++ b/functions.php
@@ -1912,7 +1912,7 @@ function alert_footer_copyright_changed(){ ?>
 <?php }
 function check_footer_copyright(){
 	$footer = file_get_contents(get_theme_root() . "/" . wp_get_theme() -> template . "/footer.php");
-	if ((strpos($footer, "github.com/solstice23/argon-theme") === false) && (strpos($footer, "solstice23.top") === false) && (strpos($footer, "solstice23.top") === false)){
+	if ((strpos($footer, "github.com/solstice23/argon-theme") === false) && (strpos($footer, "solstice23.top") === false)){
 		add_action('admin_notices', 'alert_footer_copyright_changed');
 	}
 }


### PR DESCRIPTION
获取版本号时 `wp_get_theme() -> Version` 如果在子主题启用的情况下会获取到子主题的版本号，然后再去加载CDN时就会因为**版本号不存在/版本号不对应**产生CDN 404或者文件版本不匹配出现错误（亲身经历）。

顺便，修改了一段重复的判断代码，详见 .diff 