### PR TITLE
allow custom post type search filtering & fixed #403

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -3079,29 +3079,20 @@ function init_shuoshuo(){
 }
 
 function argon_get_search_post_type_array(){
-	$search_filter_option = get_option('argon_search_post_filter', 'post,page');
+	$search_filter_type_option = get_option('argon_search_post_types');
+	$search_filter_option = get_option('argon_search_post_filter');
 	if (!isset($_GET['post_type'])) {
 		if ($search_filter_option == 'off'){
-			return get_post_types();
+			return get_post_types(); 
 		}
-		$default = explode(',', $search_filter_option);
-		return $default;
+		if (! in_array('shuoshuo', explode(',',$search_filter_option)) AND array_search('shuoshuo', $search_filter_type_option)){
+			unset($search_filter_type_option[array_search('shuoshuo', $search_filter_type_option)]);
+			return $search_filter_type_option;
+		}
+		return $search_filter_type_option;
 	}
 	$post_type = $_GET['post_type'];
-	$arr = array();
-	if (strpos($post_type, 'post') !== false) {
-		array_push($arr, 'post');
-	}
-	if (strpos($post_type, 'page') !== false) {
-		array_push($arr, 'page');
-	}
-	if (strpos($post_type, 'shuoshuo') !== false && !in_array('hide_shuoshuo', explode(',', $search_filter_option))) {
-		array_push($arr, 'shuoshuo');
-	}
-	if (count($arr) == 0) {
-		array_push($arr, 'none');
-	}
-	return $arr;
+	return explode(',', $post_type);
 }
 function search_filter($query) {
 	if (!$query -> is_search || is_admin()) {

--- a/search.php
+++ b/search.php
@@ -8,23 +8,22 @@
 				<?php _e('的搜索结果', 'argon');?>
 			</p>
 			<?php 
-				$search_post_type = argon_get_search_post_type_array();
-				if (get_option('argon_search_post_filter', 'post,page') != 'off'){ ?>
+				$search_post_types_checked = argon_get_search_post_type_array(); // array
+				$search_post_types = get_option('argon_search_post_types'); // array
+				$search_post_filter = get_option('argon_search_post_filter', 'post,page'); // string
+				if ($search_post_filter != 'off'){ ?>
 					<div class="search-filters">
-						<div class="custom-control custom-checkbox search-filter-wrapper">
-							<input class="custom-control-input search-filter" name="post" id="search_filter_post" type="checkbox" <?php echo in_array('post', $search_post_type) ? 'checked="true"' : ''; ?>>
-							<label class="custom-control-label" for="search_filter_post">文章</label>
-						</div>
-						<div class="custom-control custom-checkbox search-filter-wrapper">
-							<input class="custom-control-input search-filter" name="page" id="search_filter_page" type="checkbox" <?php echo in_array('page', $search_post_type) ? 'checked="true"' : ''; ?>>
-							<label class="custom-control-label" for="search_filter_page">页面</label>
-						</div>
-						<?php if (strpos(get_option('argon_search_post_filter', 'post,page'), 'hide_shuoshuo') === false) { ?>
+						<?php foreach($search_post_types as $search_post_type): 
+							$obj = get_post_type_object( $search_post_type );
+							$post_type_label = $obj->label;
+							if(! (in_array('hide_shuoshuo', explode(',', $search_post_filter)) AND $search_post_type == 'shuoshuo')):
+						?>
 							<div class="custom-control custom-checkbox search-filter-wrapper">
-								<input class="custom-control-input search-filter" name="shuoshuo" id="search_filter_shuoshuo" type="checkbox" <?php echo in_array('shuoshuo', $search_post_type) ? 'checked="true"' : ''; ?>>
-								<label class="custom-control-label" for="search_filter_shuoshuo">说说</label>
+								<input class="custom-control-input search-filter" name=<?php echo $search_post_type?> id="search_filter_<?php echo $search_post_type?>" type="checkbox" <?php echo in_array($search_post_type, $search_post_types_checked) ? 'checked="true"' : ''; ?>>
+								<label class="custom-control-label" for="search_filter_<?php echo $search_post_type ?>"><?php echo $post_type_label ?></label>
 							</div>
-						<?php } ?>
+							<?php endif ?>
+						<?php endforeach ?>
 					</div>
 					<script>
 						$(".search-filter").prop("checked", false);

--- a/settings.php
+++ b/settings.php
@@ -1595,9 +1595,24 @@ window.pjaxLoaded = function(){
 								<option value="off" <?php if ($argon_search_post_filter=='off'){echo 'selected';} ?>><?php _e('禁用', 'argon');?></option>
 								<option value="post,page" <?php if ($argon_search_post_filter=='post,page'){echo 'selected';} ?>><?php _e('启用，默认不包括说说', 'argon');?></option>
 								<option value="post,page,shuoshuo" <?php if ($argon_search_post_filter=='post,page,shuoshuo'){echo 'selected';} ?>><?php _e('启用，默认包括说说', 'argon');?></option>
-								<option value="post,page,hide_shuoshuo" <?php if ($argon_search_post_filter=='post,page,hide_shuoshuo'){echo 'selected';} ?>><?php _e('启用，隐藏说说分类', 'argon');?></option>
+								<!-- <option value="post,page,hide_shuoshuo" <?php if ($argon_search_post_filter=='post,page,hide_shuoshuo'){echo 'selected';} ?>><?php _e('启用，隐藏说说分类', 'argon');?></option> -->
 							</select>
 							<p class="description"><?php _e('开启后，将会在搜索结果界面显示一个过滤器，支持搜索说说', 'argon');?></p>
+						</td>
+					</tr>
+					<th><label><?php _e('可以搜索到的内容', 'argon');?></label></th>
+						<td>
+							<?php 
+								$get_post_types_args = array(
+									'public'   => true,
+									);
+								$post_types_object = get_post_types($get_post_types_args, 'objects');  // objects
+								$argon_search_post_types = get_option('argon_search_post_types', get_post_types()); // array
+								foreach ($post_types_object as $post_type): 
+							?>
+									<label><input type="checkbox" name="argon_search_post_types[]" value=<?php echo $post_type->name;?> <?php if (in_array($post_type->name, $argon_search_post_types)){echo 'checked';};?>><?php echo $post_type->label;?></label>
+							<?php endforeach?>
+							<p class="description"><?php _e('当搜索内容过滤器启用时，允许搜索的内容类型', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
@@ -1978,6 +1993,12 @@ function argon_update_option_checkbox($name){
 		update_option($name, 'false');
 	}
 }
+function argon_update_option_array($name){
+	update_option($name, array());
+	$value = $_POST[$name];
+	update_option($name, $value);
+	// see: https://global-s-h.com/article/article.php?id=29
+}
 function argon_update_themeoptions(){
 	if (!isset($_POST['update_themeoptions'])){
 		return;
@@ -2048,6 +2069,7 @@ function argon_update_themeoptions(){
 		argon_update_option('argon_who_can_visit_comment_edit_history');
 		argon_update_option('argon_home_show_shuoshuo');
 		argon_update_option('argon_search_post_filter');
+		argon_update_option_array('argon_search_post_types');
 		argon_update_option('argon_darkmode_autoswitch');
 		argon_update_option('argon_enable_amoled_dark');
 		argon_update_option('argon_outdated_info_time_type');


### PR DESCRIPTION

## 允许自定义内容类型使用搜索结果过滤器
关于对 issue #403 方案1的实现
备注：以下截图中，`vasp 的 incar` 文章的 post_type 为 docs 。
### 当禁用搜索过滤器时，允许搜索所有内容类型，搜索页面不显示过滤器
![image](https://user-images.githubusercontent.com/44738481/153802429-2cfd9199-260b-40af-83f9-2255e4cdae34.png)
![image](https://user-images.githubusercontent.com/44738481/153802605-d0529b35-c385-48e7-8c3f-a8434b48e1fb.png)


### 当启用搜索过滤器时，允许搜索`可以搜索到的内容类型`中勾选的内容类型，根据启用的选项判断是否默认勾选`shuoshuo` 。
#### 默认不勾选说说
![image](https://user-images.githubusercontent.com/44738481/153802677-a1573f4a-e025-461b-aeb3-adc0bdc1ecbd.png)
![image](https://user-images.githubusercontent.com/44738481/153802653-89bac942-ff8b-4445-996f-b0b0b3759a0a.png)
#### 默认勾选说说
![image](https://user-images.githubusercontent.com/44738481/153802741-152cd484-0cad-4394-afc8-6ac341899b1d.png)
![image](https://user-images.githubusercontent.com/44738481/153802722-39c9b711-5c50-45c6-828c-9bc6d3dc88e4.png)

#### 原 默认隐藏说说
![image](https://user-images.githubusercontent.com/44738481/153802963-add4e27c-b72f-4596-9eae-fba1848eb4bb.png)
![image](https://user-images.githubusercontent.com/44738481/153802980-3cd6ab81-66ae-4bc9-87c2-34973fe0663d.png)


已经考虑到原有设置的兼容性。