### PR TITLE
使用其他浏览计数插件的数据

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -663,9 +663,14 @@ function get_article_meta($type){
 				</div>';
 	}
 	if ($type == 'views'){
+		if (function_exists('pvc_get_post_views')){
+			$views = pvc_get_post_views(get_the_ID());
+		}else{
+			$views = get_post_views(get_the_ID());
+		}
 		return '<div class="post-meta-detail post-meta-detail-views">
 					<i class="fa fa-eye" aria-hidden="true"></i> ' .
-					get_post_views(get_the_ID()) .
+					$views .
 				'</div>';
 	}
 	if ($type == 'comments'){


### PR DESCRIPTION
有个叫Post Views Counter的开源插件挺好用的，可否在装了它的情况下显示它的数据呢。可以解决[#340](https://github.com/solstice23/argon-theme/issues/340)这种问题

它的函数：https://github.com/dfactoryplugins/post-views-counter/blob/master/includes/functions.php