### PR TITLE
Corrected display name of Source Global CDN

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1023,7 +1023,7 @@ function set_comment_upvotes($id){
 	return $upvotes;
 }
 function is_comment_upvoted($id){
-	$upvotedList = $_COOKIE['argon_comment_upvoted'] ?? '';
+	$upvotedList = isset( $_COOKIE['argon_comment_upvoted'] ) ? $_COOKIE['argon_comment_upvoted'] : '';
 	if (in_array($id, explode(',', $upvotedList))){
 		return true;
 	}
@@ -1043,7 +1043,7 @@ function upvote_comment(){
 			'total_upvote' => 0
 		)));
 	}
-	$upvotedList = $_COOKIE['argon_comment_upvoted'] ?? '';
+	$upvotedList = isset( $_COOKIE['argon_comment_upvoted'] ) ? $_COOKIE['argon_comment_upvoted'] : '';
 	if (in_array($ID, explode(',', $upvotedList))){
 		exit(json_encode(array(
 			'status' => 'failed',
@@ -1979,7 +1979,7 @@ function set_shuoshuo_upvotes($ID){
 function upvote_shuoshuo(){
 	header('Content-Type:application/json; charset=utf-8');
 	$ID = $_POST["shuoshuo_id"];
-	$upvotedList = $_COOKIE['argon_shuoshuo_upvoted'] ?? '';
+	$upvotedList = isset( $_COOKIE['argon_shuoshuo_upvoted'] ) ? $_COOKIE['argon_shuoshuo_upvoted'] : '';
 	if (in_array($ID, explode(',', $upvotedList))){
 		exit(json_encode(array(
 			'status' => 'failed',
@@ -2406,7 +2406,7 @@ function argon_admin_i18n_info(){
 add_filter('admin_head', 'argon_admin_i18n_info');
 //主题文章短代码解析
 function shortcode_content_preprocess($attr, $content = ""){
-	if ($attr['nested'] ?? 'true' != 'false'){
+	if ( isset( $attr['nested'] ) ? $attr['nested'] : 'true' != 'false' ){
 		return do_shortcode($content);
 	}else{
 		return $content;
@@ -2420,7 +2420,7 @@ add_shortcode('label','shortcode_label');
 function shortcode_label($attr,$content=""){
 	$content = shortcode_content_preprocess($attr, $content);
 	$out = "<span class='badge";
-	$color = $attr['color'] ?? 'indigo';
+	$color = isset( $attr['color'] ) ? $attr['color'] : 'indigo';
 	switch ($color){
 		case 'green':
 			$out .= " badge-success";
@@ -2439,7 +2439,7 @@ function shortcode_label($attr,$content=""){
 			$out .= " badge-primary";
 			break;
 	}
-	$shape = $attr['shape'] ?? 'square';
+	$shape = isset( $attr['shape'] ) ? $attr['shape'] : 'square';
 	if ($shape=="round"){
 		$out .= " badge-pill";
 	}
@@ -2453,10 +2453,10 @@ function shortcode_progressbar($attr,$content=""){
 	if ($content != ""){
 		$out .= "<div class='progress-label'><span>" . $content . "</span></div>";
 	}
-	$progress = $attr['progress'] ?? 100;
+	$progress = isset( $attr['progress'] ) ? $attr['progress'] : 100;
 	$out .= "<div class='progress-percentage'><span>" . $progress . "%</span></div>";
 	$out .= "</div><div class='progress'><div class='progress-bar";
-	$color = $attr['color'] ?? 'indigo';
+	$color = isset( $attr['color'] ) ? $attr['color'] : 'indigo';
 	switch ($color){
 		case 'indigo':
 			$out .= " bg-primary";
@@ -2483,7 +2483,7 @@ function shortcode_progressbar($attr,$content=""){
 add_shortcode('checkbox','shortcode_checkbox');
 function shortcode_checkbox($attr,$content=""){
 	$content = shortcode_content_preprocess($attr, $content);
-	$checked = $attr['checked'] ?? 'false';
+	$checked = isset( $attr['checked'] ) ? $attr['checked'] : 'false';
 	$inline = isset($attr['inline']) ? $attr['checked'] : 'false';
 	$out = "<div class='shortcode-todo custom-control custom-checkbox";
 	if ($inline == 'true'){
@@ -2501,7 +2501,7 @@ add_shortcode('alert','shortcode_alert');
 function shortcode_alert($attr,$content=""){
 	$content = shortcode_content_preprocess($attr, $content);
 	$out = "<div class='alert";
-	$color = $attr['color'] ?? 'indigo';
+	$color = isset( $attr['color'] ) ? $attr['color'] : 'indigo';
 	switch ($color){
 		case 'indigo':
 			$out .= " alert-primary";
@@ -2540,7 +2540,7 @@ add_shortcode('admonition','shortcode_admonition');
 function shortcode_admonition($attr,$content=""){
 	$content = shortcode_content_preprocess($attr, $content);
 	$out = "<div class='admonition shadow-sm";
-	$color = $attr['color'] ?? 'indigo';
+	$color = isset( $attr['color'] ) ? $attr['color'] : 'indigo';
 	switch ($color){
 		case 'indigo':
 			$out .= " admonition-primary";
@@ -2585,12 +2585,12 @@ add_shortcode('collapse','shortcode_collapse_block');
 add_shortcode('fold','shortcode_collapse_block');
 function shortcode_collapse_block($attr,$content=""){
 	$content = shortcode_content_preprocess($attr, $content);
-	$collapsed = $attr['collapsed'] ?? 'true';
-	$show_border_left = $attr['showleftborder'] ?? 'false';
+	$collapsed = isset( $attr['collapsed'] ) ? $attr['collapsed'] : 'true';
+	$show_border_left = isset( $attr['showleftborder'] ) ? $attr['showleftborder'] : 'false';
 	$out = "<div " ;
 	$out .= " class='collapse-block shadow-sm";
-	$color = $attr['color'] ?? 'none';
-	$title = $attr['title'] ?? '';
+	$color = isset( $attr['color'] ) ? $attr['color'] : 'none';
+	$title = isset( $attr['title'] ) ? $attr['title'] : '';
 	switch ($color){
 		case 'indigo':
 			$out .= " collapse-block-primary";
@@ -2642,13 +2642,13 @@ function shortcode_collapse_block($attr,$content=""){
 }
 add_shortcode('friendlinks','shortcode_friend_link');
 function shortcode_friend_link($attr,$content=""){
-	$sort = $attr['sort'] ?? 'name';
-	$order = $attr['order'] ?? 'ASC';
+	$sort = isset( $attr['sort'] ) ? $attr['sort'] : 'name';
+	$order = isset( $attr['order'] ) ? $attr['order'] : 'ASC';
 	$friendlinks = get_bookmarks( array(
 		'orderby' => $sort ,
 		'order'   => $order
 	));
-	$style = $attr['style'] ?? '1';
+	$style = isset( $attr['style'] ) ? $attr['style'] : '1';
 	switch ($style) {
 		case '1':
 			$class = "friend-links-style1";
@@ -2704,7 +2704,7 @@ function shortcode_friend_link_simple($attr,$content=""){
 	$content = trim(strip_tags($content));
 	$entries = explode("\n" , $content);
 
-	$shuffle = $attr['shuffle'] ?? 'false';
+	$shuffle = isset( $attr['shuffle'] ) ? $attr['shuffle'] : 'false';
 	if ($shuffle == "true"){
 		mt_srand();
 		$group_start = 0;
@@ -2821,8 +2821,8 @@ add_shortcode('spoiler','shortcode_hidden');
 function shortcode_hidden($attr,$content=""){
 	$content = shortcode_content_preprocess($attr, $content);
 	$out = "<span class='argon-hidden-text";
-	$tip = $attr['tip'] ?? '';
-	$type = $attr['type'] ?? 'blur';
+	$tip = isset( $attr['tip'] ) ? $attr['tip'] : '';
+	$type = isset( $attr['type'] ) ? $attr['type'] : 'blur';
 	if ($type == "background"){
 		$out .= " argon-hidden-text-background";
 	}else{
@@ -2838,10 +2838,10 @@ function shortcode_hidden($attr,$content=""){
 add_shortcode('github','shortcode_github');
 function shortcode_github($attr,$content=""){
 	$github_info_card_id = mt_rand(1000000000 , 9999999999);
-	$author = $attr['author'] ?? '';
-	$project = $attr['project'] ?? '';
-	$getdata = $attr['getdata'] ?? 'frontend';
-	$size = $attr['size'] ?? 'full';
+	$author = isset( $attr['author'] ) ? $attr['author'] : '';
+	$project = isset( $attr['project'] ) ? $attr['project'] : '';
+	$getdata = isset( $attr['getdata'] ) ? $attr['getdata'] : 'frontend';
+	$size = isset( $attr['size'] ) ? $attr['size'] : 'full';
 
 	$description = "";
 	$stars = "";
@@ -2907,11 +2907,11 @@ function shortcode_github($attr,$content=""){
 }
 add_shortcode('video','shortcode_video');
 function shortcode_video($attr,$content=""){
-	$url = $attr['mp4'] ?? '';
-	$url = $attr['url'] ?? $url;
-	$width = $attr['width'] ?? '';
-	$height = $attr['height'] ?? '';
-	$autoplay = $attr['autoplay'] ?? 'false';
+	$url = isset( $attr['mp4'] ) ? $attr['mp4'] : '';
+	$url = isset( $attr['url'] ) ? $attr['url'] : $url;
+	$width = isset( $attr['width'] ) ? $attr['width'] : '';
+	$height = isset( $attr['height'] ) ? $attr['height'] : '';
+	$autoplay = isset( $attr['autoplay'] ) ? $attr['autoplay'] : 'false';
 	$out = "<video";
 	if ($width != ''){
 		$out .= " width='" . $width . "'";
@@ -2933,12 +2933,12 @@ function shortcode_hide_reading_time($attr,$content=""){
 }
 add_shortcode('post_time','shortcode_post_time');
 function shortcode_post_time($attr,$content=""){
-	$format = $attr['format'] ?? 'Y-n-d G:i:s';
+	$format = isset( $attr['format'] ) ? $attr['format'] : 'Y-n-d G:i:s';
 	return get_the_time($format);
 }
 add_shortcode('post_modified_time','shortcode_post_modified_time');
 function shortcode_post_modified_time($attr,$content=""){
-	$format = $attr['format'] ?? 'Y-n-d G:i:s';
+	$format = isset( $attr['format'] ) ? $attr['format'] : 'Y-n-d G:i:s';
 	return get_the_modified_time($format);
 }
 add_shortcode('noshortcode','shortcode_noshortcode');

--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,6 @@
 <?php
 if (version_compare( $GLOBALS['wp_version'], '4.4-alpha', '<' )) {
-	echo "<div style='background: #5e72e4;color: #fff;font-size: 30px;padding: 50px 30px;position: fixed;width: 100%;left: 0;right: 0;bottom: 0px;z-index: 2147483647;'>" . __("Argon 主题不支持 Wordpress 4.4 以下版本，请更新 Wordpress", 'argon') . "</div>";
+	echo "<div style='background: #5e72e4;color: #fff;font-size: 30px;padding: 50px 30px;position: fixed;width: 100%;left: 0;right: 0;bottom: 0;z-index: 2147483647;'>" . __("Argon 主题不支持 Wordpress 4.4 以下版本，请更新 Wordpress", 'argon') . "</div>";
 }
 function theme_slug_setup() {
 	add_theme_support('title-tag');
@@ -440,7 +440,7 @@ function get_seo_description(){
 	global $post;
 	if (is_single() || is_page()){
 		if (get_the_excerpt() != ""){
-			return preg_replace('/ \[&hellip;\]$/', '&hellip;', get_the_excerpt());
+			return preg_replace('/ \[&hellip;]$/', '&hellip;', get_the_excerpt());
 		}
 		if (!post_password_required()){
 			return htmlspecialchars(mb_substr(str_replace("\n", '', strip_tags($post -> post_content)), 0, 50)) . "...";
@@ -794,10 +794,7 @@ function send_mail($to, $subject, $content){
 	wp_mail($to, $subject, $content, array('Content-Type: text/html; charset=UTF-8'));
 }
 function check_email_address($email){
-	if (!preg_match("/^\w+((-\w+)|(\.\w+))*\@[A-Za-z0-9]+((\.|-)[A-Za-z0-9]+)*\.[A-Za-z0-9]+$/", $email)) {
-		return false;
-	}
-	return true;
+	return (bool) preg_match( "/^\w+((-\w+)|(\.\w+))*@[A-Za-z0-9]+(([.\-])[A-Za-z0-9]+)*\.[A-Za-z0-9]+$/", $email );
 }
 //检验评论 Token 和用户 Token 是否一致
 function check_comment_token($id){
@@ -887,23 +884,19 @@ function can_visit_comment_edit_history($id){
 	switch ($who_can_visit_comment_edit_history) {
 		case 'everyone':
 			return true;
-			break;
 
 		case 'commentsender':
 			if (check_comment_token($id) || check_comment_userid($id)){
 				return true;
 			}
 			return false;
-			break;
 
 		default:
 			if (current_user_can("moderate_comments")){
 				return true;
 			}
 			return false;
-			break;
 	}
-	return false;
 }
 //获取评论编辑记录
 function get_comment_edit_history(){
@@ -1945,7 +1938,7 @@ if (get_option('argon_gravatar_cdn' , '') != ''){
 	add_filter('get_avatar_url', 'gravatar_cdn');
 }
 function text_gravatar($url){
-	$url = preg_replace("/[\?\&]d[^&]+/i", "" , $url);
+	$url = preg_replace("/[?&]d[^&]+/i", "" , $url);
 	$url .= '&d=404';
 	return $url;
 }

--- a/functions.php
+++ b/functions.php
@@ -19,8 +19,7 @@ switch ($argon_assets_path) {
     case "fastgit":
 	    $GLOBALS['assets_path'] = "https://raw.fastgit.org/solstice23/argon-theme/v" . $argon_version;
         break;
-    case "AHCDN":
-    case "sourcestorage":
+    case "sourcegcdn":
 	    $GLOBALS['assets_path'] = "https://gh.sourcegcdn.com/solstice23/argon-theme/v" . $argon_version;
         break;
 	case "jsdelivr_gcore":

--- a/settings.php
+++ b/settings.php
@@ -283,7 +283,7 @@ function themeoptions_page(){
 								<option value="default" <?php if ($argon_assets_path=='default'){echo 'selected';} ?>><?php _e('不使用', 'argon');?></option>
 								<option value="jsdelivr" <?php if ($argon_assets_path=='jsdelivr'){echo 'selected';} ?>>Jsdelivr</option>
 								<option value="fastgit" <?php if ($argon_assets_path=='fastgit'){echo 'selected';} ?>>Fastgit</option>
-								<option value="sourcestorage" <?php if ($argon_assets_path=='sourcestorage'){echo 'selected';} ?>>Source Storage</option>
+								<option value="sourcegcdn" <?php if ($argon_assets_path=='sourcegcdn'){echo 'selected';} ?>>Source Global CDN</option>
 								<option value="jsdelivr_gcore" <?php if ($argon_assets_path=='jsdelivr_gcore'){echo 'selected';} ?>>Jsdelivr (gcore)</option>
 								<option value="jsdelivr_fastly" <?php if ($argon_assets_path=='jsdelivr_fastly'){echo 'selected';} ?>>Jsdelivr (fastly)</option>
 								<option value="jsdelivr_cf" <?php if ($argon_assets_path=='jsdelivr_cf'){echo 'selected';} ?>>Jsdelivr (cf)</option>
@@ -447,7 +447,7 @@ function themeoptions_page(){
 								<input type="checkbox" name="argon_banner_background_hide_shapes" value="true" <?php if ($hide_shapes=='true'){echo 'checked';}?>/>	<?php _e('隐藏背景半透明圆', 'argon');?>
 							</label>
 							<p class="description"><strong><?php _e('如果设置了背景图则不生效', 'argon');?></strong>
-								</br><div style="margin-top: 15px;"><?php _e('样式预览 (推荐选择前三个样式)', 'argon');?></div>
+								<br/><div style="margin-top: 15px;"><?php _e('样式预览 (推荐选择前三个样式)', 'argon');?></div>
 								<div style="margin-top: 10px;">
 									<div class="banner-background-color-type-preview" style="background:linear-gradient(150deg,#281483 15%,#8f6ed5 70%,#d782d9 94%);"><?php _e('样式', 'argon');?> 1</div>
 									<div class="banner-background-color-type-preview" style="background:linear-gradient(150deg,#7795f8 15%,#6772e5 70%,#555abf 94%);"><?php _e('样式', 'argon');?> 2</div>
@@ -842,7 +842,7 @@ function themeoptions_page(){
 								<option value="article-header-style-1" <?php if ($argon_article_header_style=='article-header-style-1'){echo 'selected';} ?>><?php _e('样式 1', 'argon');?></option>
 								<option value="article-header-style-2" <?php if ($argon_article_header_style=='article-header-style-2'){echo 'selected';} ?>><?php _e('样式 2', 'argon');?></option>
 							</select>
-							<p class="description"><?php _e('样式预览', 'argon');?> :</br>
+							<p class="description"><?php _e('样式预览', 'argon');?> :<br/>
 								<div class="article-header-style-preview style-default"><?php _e('默认样式', 'argon');?></div>
 								<div class="article-header-style-preview style-1"><?php _e('样式 1', 'argon');?></div>
 								<div class="article-header-style-preview style-2"><?php _e('样式 2', 'argon');?></div>

--- a/settings.php
+++ b/settings.php
@@ -52,7 +52,7 @@ function themeoptions_page(){
 							<input type="color" class="regular-text" name="argon_theme_color" value="<?php echo get_option('argon_theme_color') == "" ? "#5e72e4" : get_option('argon_theme_color'); ?>" style="height:40px;width: 80px;cursor: pointer;"/>
 							<input type="text" readonly name="argon_theme_color_hex_preview" value="<?php echo get_option('argon_theme_color') == "" ? "#5e72e4" : get_option('argon_theme_color'); ?>" style="height: 40px;width: 80px;vertical-align: bottom;background: #fff;cursor: pointer;" onclick="$('input[name=\'argon_theme_color\']').click()"/></p>
 							<p class="description"><div style="margin-top: 15px;"><?php _e("选择预置颜色 或", 'argon');?> <span onclick="$('input[name=\'argon_theme_color\']').click()" style="text-decoration: underline;cursor: pointer;"><?php _e("自定义色值", 'argon');?></span>
-								</br></br><?php _e("预置颜色：", 'argon');?></div>
+								<br/><br/><?php _e("预置颜色：", 'argon');?></div>
 								<div class="themecolor-preview-container">
 									<div class="themecolor-preview-box"><div class="themecolor-preview" style="background:#5e72e4;" color="#5e72e4"></div><div class="themecolor-name">Argon (<?php _e("默认", 'argon');?>)</div></div>
 									<div class="themecolor-preview-box"><div class="themecolor-preview" style="background:#fa7298;" color="#fa7298"></div><div class="themecolor-name"><?php _e("粉", 'argon');?></div></div>
@@ -67,7 +67,7 @@ function themeoptions_page(){
 									<div class="themecolor-preview-box"><div class="themecolor-preview" style="background:#212121;" color="#212121"></div><div class="themecolor-name"><?php _e("黑", 'argon');?></div></div>
 									<div class="themecolor-preview-box"><div class="themecolor-preview" style="background:#795547;" color="#795547"></div><div class="themecolor-name"><?php _e("棕", 'argon');?></div></div>
 								</div>
-								</br><?php _e('主题色与 "Banner 渐变背景样式" 选项搭配使用效果更佳', 'argon');?>
+								<br/><?php _e('主题色与 "Banner 渐变背景样式" 选项搭配使用效果更佳', 'argon');?>
 								<script>
 									$("input[name='argon_theme_color']").on("change" , function(){
 										$("input[name='argon_theme_color_hex_preview']").val($("input[name='argon_theme_color']").val());
@@ -110,7 +110,7 @@ function themeoptions_page(){
 								<option value="true" <?php if ($argon_enable_immersion_color=='true'){echo 'selected';} ?>><?php _e('开启', 'argon');?></option>
 								<option value="false" <?php if ($argon_enable_immersion_color=='false'){echo 'selected';} ?>><?php _e('关闭', 'argon');?></option>
 							</select>
-							<p class="description"><?php _e('开启后，主题色将会全局沉浸。</br>页面背景、卡片及页面上的其它元素会变为沉浸式主题色（气氛色）。类似 Material You。', 'argon');?></br></p>
+							<p class="description"><?php _e('开启后，主题色将会全局沉浸。<br/>页面背景、卡片及页面上的其它元素会变为沉浸式主题色（气氛色）。类似 Material You。', 'argon');?><br/></p>
 							<div style="display: flex;flex-direction: row;flex-wrap: wrap;align-items: center;margin-top:15px;">
 								<div class="immersion-color-example" style="background: #f4f5f7;"><div class="immersion-color-example-card" style="background: #fff;"></div></div>
 								<div class="immersion-color-example-arrow"><span class="dashicons dashicons-arrow-right-alt"></span></div>
@@ -130,7 +130,7 @@ function themeoptions_page(){
 								<option value="system" <?php if ($argon_darkmode_autoswitch=='system'){echo 'selected';} ?>><?php _e('跟随系统夜间模式', 'argon');?></option>
 								<option value="time" <?php if ($argon_darkmode_autoswitch=='time'){echo 'selected';} ?>><?php _e('根据时间切换夜间模式 (22:00 ~ 7:00)', 'argon');?></option>
 							</select>
-							<p class="description"><?php _e('Argon 主题会根据这里的选项来决定是否默认使用夜间模式。', 'argon');?></br><?php _e('用户也可以手动切换夜间模式，用户的设置将保留到标签页关闭为止。', 'argon');?></p>
+							<p class="description"><?php _e('Argon 主题会根据这里的选项来决定是否默认使用夜间模式。', 'argon');?><br/><?php _e('用户也可以手动切换夜间模式，用户的设置将保留到标签页关闭为止。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
@@ -198,7 +198,7 @@ function themeoptions_page(){
 								</div>
 								<label><input name="argon_page_layout" type="radio" value="double-reverse" <?php if ($argon_page_layout=='double-reverse'){echo 'checked';} ?>> <?php _e('双栏(反转)', 'argon');?></label>
 							</div>
-							<p class="description" style="margin-top: 15px;"><?php _e('使用单栏时，关于左侧栏的设置将失效。', 'argon');?></br><?php _e('使用三栏时，请前往 "外观-小工具" 设置页面配置右侧栏内容。', 'argon');?></p>
+							<p class="description" style="margin-top: 15px;"><?php _e('使用单栏时，关于左侧栏的设置将失效。', 'argon');?><br/><?php _e('使用三栏时，请前往 "外观-小工具" 设置页面配置右侧栏内容。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
@@ -229,7 +229,7 @@ function themeoptions_page(){
 								</div>
 								<label><input name="argon_article_list_waterflow" type="radio" value="2and3" <?php if ($argon_article_list_waterflow=='2and3'){echo 'checked';} ?>> <?php _e('瀑布流 (列数自适应)', 'argon');?></label>
 							</div>
-							<p class="description" style="margin-top: 15px;"><?php _e('列数自适应的瀑布流会根据可视区宽度自动调整瀑布流列数。', 'argon');?></br><?php _e('建议只有使用单栏页面布局时才开启 3 列瀑布流。', 'argon');?></br><?php _e('所有瀑布流布局都会在屏幕宽度过小时变为单列布局。', 'argon');?></p>
+							<p class="description" style="margin-top: 15px;"><?php _e('列数自适应的瀑布流会根据可视区宽度自动调整瀑布流列数。', 'argon');?><br/><?php _e('建议只有使用单栏页面布局时才开启 3 列瀑布流。', 'argon');?><br/><?php _e('所有瀑布流布局都会在屏幕宽度过小时变为单列布局。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
@@ -310,7 +310,7 @@ function themeoptions_page(){
 						<th><label><?php _e('Wordpress 安装目录', 'argon');?></label></th>
 						<td>
 							<input type="text" class="regular-text" name="argon_wp_path" value="<?php echo get_option('argon_wp_path', '/'); ?>"/>
-							<p class="description"><?php _e('如果 Wordpress 安装在子目录中，请在此填写子目录地址（例如', 'argon');?> <code>/blog/</code><?php _e('），注意前后各有一个斜杠。默认为', 'argon');?> <code>/</code> <?php _e('。', 'argon');?></br><?php _e('如果不清楚该选项的用处，请保持默认。', 'argon');?></p>
+							<p class="description"><?php _e('如果 Wordpress 安装在子目录中，请在此填写子目录地址（例如', 'argon');?> <code>/blog/</code><?php _e('），注意前后各有一个斜杠。默认为', 'argon');?> <code>/</code> <?php _e('。', 'argon');?><br/><?php _e('如果不清楚该选项的用处，请保持默认。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr><th class="subtitle"><h3><?php _e('日期格式', 'argon');?></h3></th></tr>
@@ -337,7 +337,7 @@ function themeoptions_page(){
 								<option value="true" <?php if ($argon_enable_headroom=='true'){echo 'selected';} ?>><?php _e('滚动时自动折叠', 'argon');?></option>
 								<option value="absolute" <?php if ($argon_enable_headroom=='absolute'){echo 'selected';} ?>><?php _e('不固定', 'argon');?></option>
 							</select>
-							<p class="description"><?php _e('始终固定悬浮: 永远固定悬浮在页面最上方', 'argon');?></br><?php _e('滚动时自动折叠: 在页面向下滚动时隐藏顶栏，向上滚动时显示顶栏', 'argon');?></br><?php _e('不固定: 只有在滚动到页面最顶端时才显示顶栏', 'argon');?></p>
+							<p class="description"><?php _e('始终固定悬浮: 永远固定悬浮在页面最上方', 'argon');?><br/><?php _e('滚动时自动折叠: 在页面向下滚动时隐藏顶栏，向上滚动时显示顶栏', 'argon');?><br/><?php _e('不固定: 只有在滚动到页面最顶端时才显示顶栏', 'argon');?></p>
 						</td>
 					</tr>
 					<tr><th class="subtitle"><h3><?php _e('标题', 'argon');?></h3></th></tr>
@@ -402,7 +402,7 @@ function themeoptions_page(){
 								<option value="fullscreen" <?php if ($argon_banner_size=='fullscreen'){echo 'selected';} ?>><?php _e('全屏', 'argon');?></option>
 								<option value="hide" <?php if ($argon_banner_size=='hide'){echo 'selected';} ?>><?php _e('隐藏', 'argon');?></option>
 							</select>
-							<p class="description"><?php _e('完整: Banner 高度占用半屏', 'argon');?></br><?php _e('迷你: 减小 Banner 的内边距', 'argon');?></br><?php _e('全屏: Banner 占用全屏作为封面（仅在首页生效）', 'argon');?></br><?php _e('隐藏: 完全隐藏 Banner', 'argon');?></br></p>
+							<p class="description"><?php _e('完整: Banner 高度占用半屏', 'argon');?><br/><?php _e('迷你: 减小 Banner 的内边距', 'argon');?><br/><?php _e('全屏: Banner 占用全屏作为封面（仅在首页生效）', 'argon');?><br/><?php _e('隐藏: 完全隐藏 Banner', 'argon');?><br/></p>
 						</td>
 					</tr>
 					<tr>
@@ -419,14 +419,14 @@ function themeoptions_page(){
 									<input type="checkbox" name="argon_show_toolbar_mask" value="true" <?php if ($argon_show_toolbar_mask=='true'){echo 'checked';}?>/>	<?php _e('在顶栏添加浅色遮罩，Banner 标题添加阴影（当背景过亮影响文字阅读时勾选）', 'argon');?>
 								</label>
 							</div>
-							<p class="description"><?php _e('Banner 透明化可以使博客背景沉浸。建议在设置背景时开启此选项。该选项仅会在设置页面背景时生效。', 'argon');?></br><?php _e('开启后，Banner 背景图和渐变背景选项将失效。', 'argon');?></p>
+							<p class="description"><?php _e('Banner 透明化可以使博客背景沉浸。建议在设置背景时开启此选项。该选项仅会在设置页面背景时生效。', 'argon');?><br/><?php _e('开启后，Banner 背景图和渐变背景选项将失效。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
 						<th><label><?php _e('Banner 背景图 (地址)', 'argon');?></label></th>
 						<td>
 							<input type="text" class="regular-text" name="argon_banner_background_url" value="<?php echo get_option('argon_banner_background_url'); ?>"/>
-							<p class="description"><?php _e('需带上 http(s) ，留空则显示默认背景', 'argon');?></br><?php _e('输入', 'argon');?> <code>--bing--</code> <?php _e('调用必应每日一图', 'argon');?></p>
+							<p class="description"><?php _e('需带上 http(s) ，留空则显示默认背景', 'argon');?><br/><?php _e('输入', 'argon');?> <code>--bing--</code> <?php _e('调用必应每日一图', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
@@ -517,7 +517,7 @@ function themeoptions_page(){
 						<th><label><?php _e('左侧栏子标题（格言）', 'argon');?></label></th>
 						<td>
 							<input type="text" class="regular-text" name="argon_sidebar_banner_subtitle" value="<?php echo get_option('argon_sidebar_banner_subtitle'); ?>"/>
-							<p class="description"><?php _e('留空则不显示', 'argon');?></br><?php _e('输入', 'argon');?> <code>--hitokoto--</code> <?php _e('调用一言 API', 'argon');?></p>
+							<p class="description"><?php _e('留空则不显示', 'argon');?><br/><?php _e('输入', 'argon');?> <code>--hitokoto--</code> <?php _e('调用一言 API', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
@@ -589,7 +589,7 @@ function themeoptions_page(){
 						<th><label><?php _e('网站描述 (Description Meta 标签)', 'argon');?></label></th>
 						<td>
 							<textarea type="text" rows="5" cols="100" name="argon_seo_description"><?php echo htmlspecialchars(get_option('argon_seo_description')); ?></textarea>
-							<p class="description"><?php _e('设置针对搜索引擎的 Description Meta 标签内容。', 'argon');?></br><?php _e('在文章中，Argon 会自动根据文章内容生成描述。在其他页面中，Argon 将使用这里设置的内容。如不填，Argon 将不会在其他页面输出 Description Meta 标签。', 'argon');?></p>
+							<p class="description"><?php _e('设置针对搜索引擎的 Description Meta 标签内容。', 'argon');?><br/><?php _e('在文章中，Argon 会自动根据文章内容生成描述。在其他页面中，Argon 将使用这里设置的内容。如不填，Argon 将不会在其他页面输出 Description Meta 标签。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
@@ -742,7 +742,7 @@ function themeoptions_page(){
 						<th><label><?php _e('脚注列表标题', 'argon');?></label></th>
 						<td>
 							<input type="text" class="regular-text" name="argon_reference_list_title" value="<?php echo (get_option('argon_reference_list_title') == "" ? __('参考', 'argon') : get_option('argon_reference_list_title')); ?>"/>
-							<p class="description"><?php _e('脚注列表显示在文末，在文章中有脚注的时候会显示。</br>使用 <code>ref</code> 短代码可以在文中插入脚注。', 'argon');?></p>
+							<p class="description"><?php _e('脚注列表显示在文末，在文章中有脚注的时候会显示。<br/>使用 <code>ref</code> 短代码可以在文中插入脚注。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr><th class="subtitle"><h3><?php _e('分享', 'argon');?></h3></th></tr>
@@ -784,7 +784,7 @@ function themeoptions_page(){
 						<th><label><?php _e('文末附加内容', 'argon');?></label></th>
 						<td>
 							<textarea type="text" rows="5" cols="100" name="argon_additional_content_after_post"><?php echo htmlspecialchars(get_option('argon_additional_content_after_post')); ?></textarea>
-							<p class="description"><?php _e('将会显示在每篇文章末尾，支持 HTML 标签，留空则不显示。', 'argon');?></br><?php _e('使用 <code>%url%</code> 来代替当前页面 URL，<code>%link%</code> 来代替当前页面链接，<code>%title%</code> 来代替当前文章标题，<code>%author%</code> 来代替当前文章作者。', 'argon');?></p>
+							<p class="description"><?php _e('将会显示在每篇文章末尾，支持 HTML 标签，留空则不显示。', 'argon');?><br/><?php _e('使用 <code>%url%</code> 来代替当前页面 URL，<code>%link%</code> 来代替当前页面链接，<code>%title%</code> 来代替当前文章标题，<code>%author%</code> 来代替当前文章作者。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr><th class="subtitle"><h3><?php _e('相似文章推荐', 'argon');?></h3></th></tr>
@@ -900,9 +900,9 @@ function themeoptions_page(){
 								<option value="toast" <?php if ($argon_outdated_info_tip_type=='toast'){echo 'selected';} ?>><?php _e('在页面右上角弹出提示条', 'argon');?></option>
 							</select>
 							<?php _e('的方式提示', 'argon');?>
-							</br>
+							<br/>
 							<textarea type="text" name="argon_outdated_info_tip_content" rows="3" cols="100" style="margin-top: 15px;"><?php echo get_option('argon_outdated_info_tip_content') == '' ? __('本文最后更新于 %date_delta% 天前，其中的信息可能已经有所发展或是发生改变。', 'argpm') : get_option('argon_outdated_info_tip_content'); ?></textarea>
-							<p class="description"><?php _e('天数为 -1 表示永不提示。', 'argon');?></br><code>%date_delta%</code> <?php _e('表示文章发布/修改时间与当前时间的差距，', 'argon');?><code>%post_date_delta%</code> <?php _e('表示文章发布时间与当前时间的差距，', 'argon');?><code>%modify_date_delta%</code> <?php _e('表示文章修改时间与当前时间的差距（单位: 天）。', 'argon');?></p>
+							<p class="description"><?php _e('天数为 -1 表示永不提示。', 'argon');?><br/><code>%date_delta%</code> <?php _e('表示文章发布/修改时间与当前时间的差距，', 'argon');?><code>%post_date_delta%</code> <?php _e('表示文章发布时间与当前时间的差距，', 'argon');?><code>%modify_date_delta%</code> <?php _e('表示文章修改时间与当前时间的差距（单位: 天）。', 'argon');?></p>
 						</td>
 					</tr>
 					<tr><th class="subtitle"><h2><?php _e('归档页面', 'argon');?></h2></th></tr>
@@ -1059,7 +1059,7 @@ function themeoptions_page(){
 												<div>
 													Katex CDN <?php _e('地址', 'argon');?>:
 													<input type="text" class="regular-text" name="argon_katex_cdn_url" value="<?php echo get_option('argon_katex_cdn_url') == '' ? '//cdn.jsdelivr.net/npm/katex@0.11.1/dist/' : get_option('argon_katex_cdn_url'); ?>"/>
-													<p class="description"><?php _e('Argon 会同时引用', 'argon');?> <code>katex.min.css</code> <?php _e('和', 'argon');?> <code>katex.min.js</code> <?php _e('两个文件，所以在此填写的是上层的路径，而不是具体的文件。注意路径后要带一个斜杠。', 'argon');?></br><?php _e('默认为', 'argon');?> <code>//cdn.jsdelivr.net/npm/katex@0.11.1/dist/</code></p>
+													<p class="description"><?php _e('Argon 会同时引用', 'argon');?> <code>katex.min.css</code> <?php _e('和', 'argon');?> <code>katex.min.js</code> <?php _e('两个文件，所以在此填写的是上层的路径，而不是具体的文件。注意路径后要带一个斜杠。', 'argon');?><br/><?php _e('默认为', 'argon');?> <code>//cdn.jsdelivr.net/npm/katex@0.11.1/dist/</code></p>
 												</div>
 											</label>
 										</th>
@@ -1169,7 +1169,7 @@ function themeoptions_page(){
 						<td>
 							<input type="text" class="regular-text" name="argon_zoomify_easing" value="<?php echo (get_option('argon_zoomify_easing') == '' ? 'cubic-bezier(0.4,0,0,1)' : get_option('argon_zoomify_easing')); ?>"/>
 							<p class="description">
-								<?php _e('例：', 'argon');?> <code>ease</code> , <code>ease-in-out</code> , <code>ease-out</code> , <code>linear</code> , <code>cubic-bezier(0.4,0,0,1)</code></br><?php _e('如果你不知道这是什么，参考', 'argon');?><a href="https://www.w3school.com.cn/cssref/pr_animation-timing-function.asp" target="_blank"><?php _e('这里', 'argon');?></a>
+								<?php _e('例：', 'argon');?> <code>ease</code> , <code>ease-in-out</code> , <code>ease-out</code> , <code>linear</code> , <code>cubic-bezier(0.4,0,0,1)</code><br/><?php _e('如果你不知道这是什么，参考', 'argon');?><a href="https://www.w3school.com.cn/cssref/pr_animation-timing-function.asp" target="_blank"><?php _e('这里', 'argon');?></a>
 							</p>
 						</td>
 					</tr>
@@ -1202,7 +1202,7 @@ function themeoptions_page(){
 					<tr>
 						<th><label><strong style="color:#ff0000;"><?php _e('注意', 'argon');?></strong></label></th>
 						<td>
-							<p class="description"><strong style="color:#ff0000;"><?php _e('Argon 使用 pjax 方式加载页面 (无刷新加载) , 所以除非页面手动刷新，否则您的脚本只会被执行一次。', 'argon');?></br>
+							<p class="description"><strong style="color:#ff0000;"><?php _e('Argon 使用 pjax 方式加载页面 (无刷新加载) , 所以除非页面手动刷新，否则您的脚本只会被执行一次。', 'argon');?><br/>
 							<?php _e('如果您想让每次页面跳转(加载新页面)时都执行脚本，请将脚本写入', 'argon');?> <code>window.pjaxLoaded</code> <?php _e('中', 'argon');?></strong> ，<?php _e('示例写法', 'argon');?>:
 							<pre>
 window.pjaxLoaded = function(){
@@ -1217,14 +1217,14 @@ window.pjaxLoaded = function(){
 						<th><label><?php _e('页头脚本', 'argon');?></label></th>
 						<td>
 							<textarea type="text" rows="15" cols="100" name="argon_custom_html_head"><?php echo htmlspecialchars(get_option('argon_custom_html_head')); ?></textarea>
-							<p class="description"><?php _e('HTML , 支持 script 等标签', 'argon');?></br><?php _e('插入到 body 之前', 'argon');?></p>
+							<p class="description"><?php _e('HTML , 支持 script 等标签', 'argon');?><br/><?php _e('插入到 body 之前', 'argon');?></p>
 						</td>
 					</tr>
 					<tr>
 						<th><label><?php _e('页尾脚本', 'argon');?></label></th>
 						<td>
 							<textarea type="text" rows="15" cols="100" name="argon_custom_html_foot"><?php echo htmlspecialchars(get_option('argon_custom_html_foot')); ?></textarea>
-							<p class="description"><?php _e('HTML , 支持 script 等标签', 'argon');?></br><?php _e('插入到 body 之后', 'argon');?></p>
+							<p class="description"><?php _e('HTML , 支持 script 等标签', 'argon');?><br/><?php _e('插入到 body 之后', 'argon');?></p>
 						</td>
 					</tr>
 					<tr><th class="subtitle"><h2><?php _e('动画', 'argon');?></h2></th></tr>
@@ -1275,8 +1275,8 @@ window.pjaxLoaded = function(){
 								<option value="page" <?php if ($argon_comment_pagination_type=='page'){echo 'selected';} ?>><?php _e('页码', 'argon');?></option>
 							</select>
 							<p class="description">
-								<?php _e('无限加载：点击 "加载更多" 按钮来加载更多评论。', 'argon');?></br>
-								<?php _e('页码：显示页码来分页。', 'argon');?></br>
+								<?php _e('无限加载：点击 "加载更多" 按钮来加载更多评论。', 'argon');?><br/>
+								<?php _e('页码：显示页码来分页。', 'argon');?><br/>
 								<span class="go-to-wp-comment-settings"><?php _e('选择"无限加载"时，如果开启了评论分页，请将 Wordpress 的讨论设置设为 "默认显示<b>最后</b>一页，在每个页面顶部显示<b>新的</b>评论"。', 'argon');?> <a href="./options-discussion.php" target="_blank"><?php _e('去设置', 'argon');?>&gt;&gt;&gt;</a></span>
 								<?php if (get_option('page_comments') == '1' && get_option('default_comments_page') != 'newest' && get_option('comment_order') != 'desc') {
 									echo '<script>$(".go-to-wp-comment-settings").addClass("wrong-options");</script>';
@@ -1313,7 +1313,7 @@ window.pjaxLoaded = function(){
 								<option value="true" <?php if ($argon_comment_emotion_keyboard=='true'){echo 'selected';} ?>><?php _e('启用', 'argon');?></option>
 								<option value="false" <?php if ($argon_comment_emotion_keyboard=='false'){echo 'selected';} ?>><?php _e('禁用', 'argon');?></option>
 							</select>
-							<p class="description"><?php _e('开启后评论支持插入表情，会在评论输入框下显示表情键盘按钮。', 'argon');?></br><a href="https://argon-docs.solstice23.top/#/emotions" target="_blank"><?php _e('如何添加新的表情或修改已有表情列表？', 'argon');?></a></p>
+							<p class="description"><?php _e('开启后评论支持插入表情，会在评论输入框下显示表情键盘按钮。', 'argon');?><br/><a href="https://argon-docs.solstice23.top/#/emotions" target="_blank"><?php _e('如何添加新的表情或修改已有表情列表？', 'argon');?></a></p>
 						</td>
 					</tr>
 					<tr>
@@ -1497,7 +1497,7 @@ window.pjaxLoaded = function(){
 						<th><label>Gravatar CDN</label></th>
 						<td>
 							<input type="text" class="regular-text" name="argon_gravatar_cdn" value="<?php echo get_option('argon_gravatar_cdn' , ''); ?>"/>
-							<p class="description"><?php _e('使用 CDN 来加速 Gravatar 在某些地区的访问，填写 CDN 地址，留空则不使用。', 'argon');?></br><?php _e('在中国速度较快的一些 CDN :', 'argon');?><code onclick="$('input[name=\'argon_gravatar_cdn\']').val(this.innerText);" style="cursor: pointer;">gravatar.pho.ink/avatar/</code> , <code onclick="$('input[name=\'argon_gravatar_cdn\']').val(this.innerText);" style="cursor: pointer;">cdn.v2ex.com/gravatar/</code> , <code onclick="$('input[name=\'argon_gravatar_cdn\']').val(this.innerText);" style="cursor: pointer;">dn-qiniu-avatar.qbox.me/avatar/</code></p>
+							<p class="description"><?php _e('使用 CDN 来加速 Gravatar 在某些地区的访问，填写 CDN 地址，留空则不使用。', 'argon');?><br/><?php _e('在中国速度较快的一些 CDN :', 'argon');?><code onclick="$('input[name=\'argon_gravatar_cdn\']').val(this.innerText);" style="cursor: pointer;">gravatar.pho.ink/avatar/</code> , <code onclick="$('input[name=\'argon_gravatar_cdn\']').val(this.innerText);" style="cursor: pointer;">cdn.v2ex.com/gravatar/</code> , <code onclick="$('input[name=\'argon_gravatar_cdn\']').val(this.innerText);" style="cursor: pointer;">dn-qiniu-avatar.qbox.me/avatar/</code></p>
 						</td>
 					</tr>
 					<tr>
@@ -1649,7 +1649,7 @@ window.pjaxLoaded = function(){
 						<th><label><?php _e('首页隐藏特定 分类/Tag 下的文章', 'argon');?></label></th>
 						<td>
 							<input type="text" class="regular-text" name="argon_hide_categories" value="<?php echo get_option('argon_hide_categories'); ?>"/>
-							<p class="description"><?php _e('输入要隐藏的 分类/Tag 的 ID，用英文逗号分隔，留空则不隐藏', 'argon');?></br><a onclick="$('#id_of_categories_and_tags').slideDown(500);" style="cursor: pointer;"><?php _e('点此查看', 'argon');?></a><?php _e('所有分类和 Tag 的 ID', 'argon');?>
+							<p class="description"><?php _e('输入要隐藏的 分类/Tag 的 ID，用英文逗号分隔，留空则不隐藏', 'argon');?><br/><a onclick="$('#id_of_categories_and_tags').slideDown(500);" style="cursor: pointer;"><?php _e('点此查看', 'argon');?></a><?php _e('所有分类和 Tag 的 ID', 'argon');?>
 								<?php
 									echo "<div id='id_of_categories_and_tags' style='display: none;'><div style='font-size: 22px;margin-bottom: 10px;margin-top: 10px;'>分类</div>";
 									$categories = get_categories(array(


### PR DESCRIPTION
d50d8777a4bd4dc84a002ad2d90cccd342c44074 Replaced the previous `??` operator with a ternary expression of `? :` to ensure PHP5 compatibility.
> But PHP5 still struggles to run WordPress...

c17de3df459d7fc7045b60a3089666e3c8f27935 Removed some redundant regex and PHP returns because they looked too painful.

9ef7e07d2497bb21a0838e397bb366aa4b801ce4  Update the display name of Source Global CDN.

Source Global CDN is an upgrade of Source Storage, which became a separate project.
<https://www.sourcegcdn.com/>

If you want, I suggest you to add an anchor to <https://www.sourcegcdn.com/> or a notice about our project, because this is a new project, and a link can make users more aware of this project.

Because it is not famous, and the project name is too long, so you cann't find it on Baidu or Google.

d50d8777a4bd4dc84a002ad2d90cccd342c44074 Replaced incorrect `</br>` with `<br/>`
