### PR TITLE
hidden shadow for language switcher on login screen

### DIFF
--- a/login.css
+++ b/login.css
@@ -4,7 +4,7 @@ body {
 .login h1 {
 	display: none;
 }
-.login form {
+#loginform {
 	background-color: #fafafa;
 	border: none;
 	border-radius: .25rem;


### PR DESCRIPTION
WordPress 5.9 版本在登录页面引入了语言切换器，参见 [Introducing new language switcher on the login screen in WP 5.9](https://make.wordpress.org/core/2021/12/20/introducing-new-language-switcher-on-the-login-screen-in-wp-5-9/)

由于语言切换器也是 `<form>` ，被应用了 `.login form` 的 `box-shadow` , 观察发现登录表单有 `id="loginform"` ，故可以将样式表 `.login form` 改为 `#loginform`。

修改前：

![Snipaste_2022-02-28_19-22-12](https://user-images.githubusercontent.com/44738481/155976140-a6041757-8264-4f65-bcfb-b0ab0b0ed5b2.png)

修改后：
![Snipaste_2022-02-28_19-22-28](https://user-images.githubusercontent.com/44738481/155976161-ddbde4c5-f5e6-4084-bf30-a4bcd7929cfe.png)


