### PR TITLE
fix #236 post-preview-layout-2 in mobile

### DIFF
--- a/assets/src/style.css
+++ b/assets/src/style.css
@@ -2044,6 +2044,19 @@ article.post-preview-layout-2 .loading-css-animation {
 	position: absolute;
 	bottom: -8px;
 }
+@media screen and (max-width: 800px) {
+    article.post-preview-layout-2 {
+        display: flex;
+        flex-direction: column;
+        padding: 0;
+    }
+    article.post-preview-layout-2 .post-header.post-header-with-thumbnail {
+        margin: 0;
+        border-radius: var(--card-radius);
+        text-align: left;
+        width: 100%;
+    }
+}
 /* 文章预览样式 3 */
 article.post-preview-layout-3 .post-header {
 	margin-bottom: 10px;


### PR DESCRIPTION
改善文章列表图文布局 2 在窄屏下的视觉体验
#236 

before:

![Snipaste_2022-03-06_15-52-11](https://user-images.githubusercontent.com/44738481/156914457-ca71a294-2e16-4225-8132-61120f45a9fb.png)

after：
![Snipaste_2022-03-06_15-51-36](https://user-images.githubusercontent.com/44738481/156914464-7c587be1-d2b9-48f2-a900-494c57adf683.png)


