### PR TITLE
fix: issue #447

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -70,7 +70,7 @@
 	}
 ?>
 <div id="post_comment" class="card shadow-sm <?php if (is_user_logged_in()) {echo("logged");}?><?php if (!$name_and_email_required) {echo(" no-need-name-email");}?><?php if (get_option('argon_comment_need_captcha') == 'false') {echo(" no-need-captcha");}?><?php if ($enable_qq_avatar == 'true') {echo(" enable-qq-avatar");}?>">
-	<div class="card-body">
+	<div class="card-body" style="overflow-x: hidden;">
 		<h2 class="post-comment-title">
 			<i class="fa fa-commenting"></i>
 			<span class="hide-on-comment-editing"><?php echo apply_filters("argon_comment_title", __('发送评论', 'argon'))?></span>

--- a/comments.php
+++ b/comments.php
@@ -70,7 +70,7 @@
 	}
 ?>
 <div id="post_comment" class="card shadow-sm <?php if (is_user_logged_in()) {echo("logged");}?><?php if (!$name_and_email_required) {echo(" no-need-name-email");}?><?php if (get_option('argon_comment_need_captcha') == 'false') {echo(" no-need-captcha");}?><?php if ($enable_qq_avatar == 'true') {echo(" enable-qq-avatar");}?>">
-	<div class="card-body" style="overflow-x: hidden;">
+	<div class="card-body">
 		<h2 class="post-comment-title">
 			<i class="fa fa-commenting"></i>
 			<span class="hide-on-comment-editing"><?php echo apply_filters("argon_comment_title", __('发送评论', 'argon'))?></span>
@@ -190,7 +190,7 @@
 						<span class="btn-inner--icon"><i class="fa fa-angle-down"></i></span>
 					</button>
 				</div></div>
-			<div class="row" style="margin-top: 5px; margin-bottom: 10px;">
+			<div class="row" style="margin-top: 5px; margin-bottom: 10px; overflow-x: hidden;">
 				<div class="col-md-12">
 					<?php if (get_option("argon_comment_allow_markdown") != "false") {?>
 						<div class="custom-control custom-checkbox comment-post-checkbox comment-post-use-markdown">

--- a/comments.php
+++ b/comments.php
@@ -190,7 +190,7 @@
 						<span class="btn-inner--icon"><i class="fa fa-angle-down"></i></span>
 					</button>
 				</div></div>
-			<div class="row" style="margin-top: 5px; margin-bottom: 10px; overflow-x: hidden;">
+			<div class="row" style="margin-top: 5px; margin-bottom: 10px; overflow-x: clip;">
 				<div class="col-md-12">
 					<?php if (get_option("argon_comment_allow_markdown") != "false") {?>
 						<div class="custom-control custom-checkbox comment-post-checkbox comment-post-use-markdown">


### PR DESCRIPTION
#447 is caused by tooltip text for private comment option overflowing at #card-body in comments section, as shown below:
![image](https://user-images.githubusercontent.com/50446405/161670522-e33c8b23-958f-4866-99dd-2bf030334d06.png)
I only patched comment section as im not very familiar with argon-design-system so im not sure if a global change will cause compatibility issues. 