### PR TITLE
Fixed a problem about alert box.

### DIFF
--- a/assets/css/argon.css
+++ b/assets/css/argon.css
@@ -6601,6 +6601,8 @@ a.badge:focus
 
     border: .0625rem solid transparent;
     border-radius: .25rem;
+
+    overflow: scroll;
 }
 
 .alert-heading


### PR DESCRIPTION
In the alert box, when a too long content , such as a long URL appeared in one line, the content inside will display out of the alert box.

This problem appears not only on mobile phones but also on PCs.

![IMG_20221009_004424](https://user-images.githubusercontent.com/33298711/194718313-0897a42a-8625-4127-be5d-98b47fa2cd71.jpg)

![Screenshot_2022-10-09-00-15-00-58_a252b927494330cdc2c8ba3b3f952e5e](https://user-images.githubusercontent.com/33298711/194718326-c2d5c92c-c26a-4763-a3c4-a41f33e66bb8.jpg)
