### PR TITLE
Fixed a problem about alert box

### DIFF
--- a/assets/src/argon-design-system/css/argon.css
+++ b/assets/src/argon-design-system/css/argon.css
@@ -6601,8 +6601,6 @@ a.badge:focus
 
     border: .0625rem solid transparent;
     border-radius: .25rem;
-
-    overflow: scroll;
 }
 
 .alert-heading

--- a/assets/src/argon-design-system/css/argon.css
+++ b/assets/src/argon-design-system/css/argon.css
@@ -6601,6 +6601,8 @@ a.badge:focus
 
     border: .0625rem solid transparent;
     border-radius: .25rem;
+
+    overflow: scroll;
 }
 
 .alert-heading

--- a/assets/src/styles/global/argon-overrides.scss
+++ b/assets/src/styles/global/argon-overrides.scss
@@ -35,3 +35,6 @@
 .btn-secondary:hover {
 	background-color: var(--color-border-on-foreground-deeper);
 }
+.alert {
+        overflow: scroll;
+}


### PR DESCRIPTION
In the alert box, when a content which is too long, such as a long URL appears in one line, the content inside will display out of the alert box. 
On the mobile:
![Problem about alert box](https://www.crrashh1542.top/img/2022/1009/01.jpg)
 
On the PC:
![also on PC](https://www.crrashh1542.top/img/2022/1009/02.jpg)

(Sorry to put PR in master branch before😰)