### PR TITLE
修复问题: Adguard 俄语过滤器导致 Banner 标题不显示

### DIFF
--- a/argontheme.js
+++ b/argontheme.js
@@ -225,7 +225,7 @@ function __(text){
 /*根据滚动高度改变顶栏透明度*/
 !function(){
 	let toolbar = document.getElementById("navbar-main");
-	let $bannerContainer = $("#banner_container");
+	let $bannerContainer = $("#banner_container_main");
 	let $content = $("#content");
 
 	let startTransitionHeight;

--- a/header.php
+++ b/header.php
@@ -419,7 +419,7 @@
 		$banner_title = get_option('argon_banner_title') == '' ? get_bloginfo('name') : get_option('argon_banner_title');
 		$enable_banner_title_typing_effect = get_option('argon_enable_banner_title_typing_effect') != 'true' ? "false" : get_option('argon_enable_banner_title_typing_effect');
 	?>
-	<div id="banner_container" class="banner-container container text-center">
+	<div id="banner_container_main" class="banner-container container text-center">
 		<?php if ($enable_banner_title_typing_effect != "true"){?>
 			<div class="banner-title text-white"><span class="banner-title-inner"><?php echo apply_filters('argon_banner_title_html', $banner_title); ?></span>
 			<?php echo get_option('argon_banner_subtitle') == '' ? '' : '<span class="banner-subtitle d-block">' . get_option('argon_banner_subtitle') . '</span>'; ?></div>


### PR DESCRIPTION
将banner容器id `banner_container` 替换为 `banner_container_main`