### PR TITLE
解决了搜索时，无法转换特殊字符的bug

### DIFF
--- a/argontheme.js
+++ b/argontheme.js
@@ -309,7 +309,7 @@ function searchPosts(word){
 		});
 	}else{
 		$.pjax({
-			url: argonConfig.wp_path + "?s=" + encodeURI(word)
+			url: argonConfig.wp_path + "?s=" + encodeURIComponent(word)
 		});
 	}
 }


### PR DESCRIPTION
解决了一个我发现的bug，bug描述：[\[Bug\] 搜索框中输入特殊字符，无法正常识别与转换 #661](https://github.com/solstice23/argon-theme/issues/661)